### PR TITLE
Scale mine size based on device pixel ratio

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
 
   function spawnShard(minX,minY,maxX,maxY){ return { pos:{x:rand(minX,maxX),y:rand(minY,maxY)}, r:8 }; }
   function spawnMines(n){
-    const arr=[]; for(let i=0;i<n;i++) arr.push({ base:{x:rand(GS.w*0.2,GS.w*0.8), y:rand(GS.h*0.2,GS.h*0.8)}, amp:{x:rand(40,140)*(Math.random()<0.5?-1:1), y:rand(30,120)*(Math.random()<0.5?-1:1)}, speed:rand(0.0004,0.001)*(Math.random()<0.5?-1:1), t:Math.random()*Math.PI*2, r:rand(10,16), hue:rand(350,20) });
+    const arr=[]; for(let i=0;i<n;i++) arr.push({ base:{x:rand(GS.w*0.2,GS.w*0.8), y:rand(GS.h*0.2,GS.h*0.8)}, amp:{x:rand(40,140)*(Math.random()<0.5?-1:1)*GS.dpr, y:rand(30,120)*(Math.random()<0.5?-1:1)*GS.dpr}, speed:rand(0.0004,0.001)*(Math.random()<0.5?-1:1), t:Math.random()*Math.PI*2, r:rand(10,16)*GS.dpr, hue:rand(350,20) });
     return arr;
   }
   const minePos=m=>({x:m.base.x+Math.sin(m.t)*m.amp.x, y:m.base.y+Math.cos(m.t*1.3)*m.amp.y});


### PR DESCRIPTION
## Summary
- Scale mine oscillation amplitudes and radius by `GS.dpr` to keep behavior consistent across DPI settings.
- Mines now maintain consistent motion with `minePos` computing positions from the updated amplitudes.

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a6311c44c8331aa278f295d2fdeea