### PR TITLE
Enhance UX with sound, accessibility, and score persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     html,body{height:100%;margin:0}
     body{display:flex;align-items:center;justify-content:center;background:linear-gradient(135deg,var(--bg1),var(--bg2));font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto}
     .wrap{width:min(1100px,96vw);height:min(78vh,800px);min-height:520px;border-radius:18px;position:relative;box-shadow:0 12px 40px rgba(0,0,0,.45);overflow:hidden}
-    canvas{display:block;width:100%;height:100%}
+    canvas{display:block;width:100%;height:100%;touch-action:none}
     .glow{pointer-events:none;position:absolute;inset:-15%;opacity:.6;background:
       radial-gradient(60% 50% at 30% 30%, rgba(34,211,238,0.12) 0%, rgba(0,0,0,0) 70%),
       radial-gradient(50% 40% at 80% 20%, rgba(167,139,250,0.10) 0%, rgba(0,0,0,0) 70%),
@@ -31,12 +31,12 @@
 <body>
   <div class="wrap">
     <div class="glow" aria-hidden></div>
-    <canvas id="game"></canvas>
+    <canvas id="game" tabindex="0" aria-label="Slingfield game" role="img"></canvas>
 
     <div class="hud">
       <div style="display:flex;gap:8px;align-items:center"><span>🚀</span><span style="font-size:12px;letter-spacing:.12em;text-transform:uppercase;color:#94a3b8">Slingfield</span></div>
       <div style="display:flex;gap:12px;align-items:center">
-        <div class="pill">Score <b id="score">0</b></div>
+        <div class="pill">Score <b id="score" aria-live="polite">0</b></div>
         <div class="pill">Best <b id="best">0</b></div>
         <div class="cooldown"><svg viewBox="0 0 36 36" width="28" height="28">
           <path d="M18 2a16 16 0 1 1 0 32a16 16 0 1 1 0-32" fill="none" stroke="rgba(255,255,255,.18)" stroke-width="3"/>
@@ -46,9 +46,9 @@
       </div>
     </div>
 
-    <div class="overlay" id="menu">
+    <div class="overlay" id="menu" role="dialog" aria-modal="true" aria-labelledby="menuTitle">
       <div class="card">
-        <div class="title">✨ <span>Slingfield — Neon Gravity</span></div>
+        <div class="title" id="menuTitle">✨ <span>Slingfield — Neon Gravity</span></div>
         <p style="margin:0 0 12px 0; font-size:14px; color:#cbd5e1">Drop short‑lived gravity wells to bend the comet. Collect shards, avoid mines. Click / tap to place a well. Max two wells, ~1 s cooldown.</p>
         <div class="btns">
           <button class="primary" id="startBtn">New Game</button>
@@ -57,9 +57,9 @@
       </div>
     </div>
 
-    <div class="overlay" id="gameover" style="display:none">
+    <div class="overlay" id="gameover" style="display:none" role="dialog" aria-modal="true" aria-labelledby="overTitle">
       <div class="card">
-        <div class="title">💥 <span>Game Over</span></div>
+        <div class="title" id="overTitle">💥 <span>Game Over</span></div>
         <p style="margin:0 0 12px 0; font-size:14px; color:#cbd5e1">Final score: <b id="finalScore">0</b> | Best: <b id="finalBest">0</b></p>
         <div class="btns">
           <button class="primary" id="retryBtn">Try Again</button>
@@ -100,6 +100,32 @@
 
   const GS={ctx,w:0,h:0,dpr,last:performance.now(),time:0,orb:null,wells:[],shard:null,mines:[],effects:[],cooldownMs:0,level:1,pointer:{x:0,y:0},phase:'menu',best:0};
 
+  const storedBest=Number(localStorage.getItem('slingfield_best'));
+  if(!isNaN(storedBest)) GS.best=storedBest;
+
+  // -------- Audio --------
+  let audioCtx=null;
+  function initAudio(){
+    if(!audioCtx){
+      const Ctx=window.AudioContext||window.webkitAudioContext;
+      if(Ctx) audioCtx=new Ctx();
+    }
+    if(audioCtx && audioCtx.state==='suspended') audioCtx.resume();
+  }
+  function playSound(freq,type='sine',duration=0.1,vol=0.15){
+    if(!audioCtx) return;
+    const osc=audioCtx.createOscillator();
+    const gain=audioCtx.createGain();
+    osc.type=type;
+    osc.frequency.value=freq;
+    osc.connect(gain);
+    gain.connect(audioCtx.destination);
+    gain.gain.setValueAtTime(vol,audioCtx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.001,audioCtx.currentTime+duration);
+    osc.start();
+    osc.stop(audioCtx.currentTime+duration);
+  }
+
   function resize(){
     const parent=canvas.parentElement;
     const bw=parent.clientWidth, bh=Math.max(520,Math.min(900,parent.clientHeight));
@@ -114,13 +140,26 @@
     const r=canvas.getBoundingClientRect(); GS.pointer.x=(e.clientX-r.left)*dpr; GS.pointer.y=(e.clientY-r.top)*dpr;
   });
   canvas.addEventListener('pointerdown',()=>{
-    if (GS.phase!=='playing') return; if (GS.cooldownMs>0) return;
-    dropWell(GS.pointer.x,GS.pointer.y); GS.cooldownMs=1000; addPulse(GS.pointer.x,GS.pointer.y,120,600,'#7dd3fc');
+    if (GS.phase!=='playing') return;
+    if (GS.cooldownMs>0) return;
+    dropWell(GS.pointer.x,GS.pointer.y);
+    playSound(220,'square',0.08,0.2);
+    GS.cooldownMs=1000; addPulse(GS.pointer.x,GS.pointer.y,120,600,'#7dd3fc');
+  });
+  canvas.addEventListener('keydown',e=>{
+    if(e.code!=='Space') return;
+    e.preventDefault();
+    if (GS.phase!=='playing') return;
+    if (GS.cooldownMs>0) return;
+    dropWell(GS.pointer.x,GS.pointer.y);
+    playSound(220,'square',0.08,0.2);
+    GS.cooldownMs=1000; addPulse(GS.pointer.x,GS.pointer.y,120,600,'#7dd3fc');
   });
 
   // -------- Game init --------
   function initGame(){
     GS.time=0; GS.level=1; GS.effects.length=0; GS.wells.length=0; GS.cooldownMs=0;
+    GS.pointer.x=GS.w/2; GS.pointer.y=GS.h/2;
     GS.orb={pos:{x:GS.w*0.3,y:GS.h*0.6}, vel:{x:0.12*dpr,y:-0.10*dpr}, r:9, score:0};
     GS.shard=spawnShard(48*dpr,48*dpr,GS.w-96*dpr,GS.h-96*dpr);
     GS.mines=spawnMines(3);
@@ -192,7 +231,9 @@
     for(const m of GS.mines) m.t+=m.speed*dt;
     // shard
     if (dist2(o.pos,GS.shard.pos) < Math.pow(o.r+GS.shard.r+4,2)){
-      o.score++; addPulse(GS.shard.pos.x,GS.shard.pos.y,20,220,'#a78bfa'); if(o.score%5===0){ GS.level++; const add=Math.min(1+Math.floor(GS.level/2),2); GS.mines.push(...spawnMines(add)); for(const m of GS.mines) m.speed*=1.06; }
+      o.score++;
+      playSound(880,'sine',0.1,0.25);
+      addPulse(GS.shard.pos.x,GS.shard.pos.y,20,220,'#a78bfa'); if(o.score%5===0){ GS.level++; const add=Math.min(1+Math.floor(GS.level/2),2); GS.mines.push(...spawnMines(add)); for(const m of GS.mines) m.speed*=1.06; }
       GS.shard=spawnShard(48*dpr,48*dpr,GS.w-96*dpr,GS.h-96*dpr); updateHud();
     }
     // collisions
@@ -213,9 +254,10 @@
   // -------- Phase control --------
   function show(el, on){ el.style.display=on?'':'none'; }
   function gameOver(){
-    GS.phase='gameover'; cancelAnimationFrame(raf); raf=null; finalScore.textContent=GS.orb.score; GS.best=Math.max(GS.best,GS.orb.score); finalBest.textContent=GS.best; updateHud(); show(menu,false); show(gameover,true);
+    playSound(110,'sawtooth',0.5,0.25);
+    GS.phase='gameover'; cancelAnimationFrame(raf); raf=null; finalScore.textContent=GS.orb.score; GS.best=Math.max(GS.best,GS.orb.score); finalBest.textContent=GS.best; localStorage.setItem('slingfield_best', GS.best); updateHud(); show(menu,false); show(gameover,true);
   }
-  function startGame(){ GS.phase='playing'; initGame(); show(menu,false); show(gameover,false); if(!raf) loop(); }
+  function startGame(){ initAudio(); GS.phase='playing'; initGame(); show(menu,false); show(gameover,false); canvas.focus(); if(!raf) loop(); }
 
   startBtn.onclick=startGame;
   retryBtn.onclick=startGame;


### PR DESCRIPTION
## Summary
- add AudioContext utilities and trigger sound for wells, shards, and game over
- persist best score via localStorage
- improve accessibility with ARIA attributes, keyboard controls, and touch-action tweaks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a600b80e88331ad65c2c6678fad11