### PR TITLE
Fix gravity well placement on touch devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,9 +137,14 @@
   new ResizeObserver(resize).observe(canvas.parentElement); resize();
 
   canvas.addEventListener('pointermove',e=>{
-    const r=canvas.getBoundingClientRect(); GS.pointer.x=(e.clientX-r.left)*dpr; GS.pointer.y=(e.clientY-r.top)*dpr;
+    const r=canvas.getBoundingClientRect();
+    GS.pointer.x=(e.clientX-r.left)*dpr;
+    GS.pointer.y=(e.clientY-r.top)*dpr;
   });
-  canvas.addEventListener('pointerdown',()=>{
+  canvas.addEventListener('pointerdown',e=>{
+    const r=canvas.getBoundingClientRect();
+    GS.pointer.x=(e.clientX-r.left)*dpr;
+    GS.pointer.y=(e.clientY-r.top)*dpr;
     if (GS.phase!=='playing') return;
     if (GS.cooldownMs>0) return;
     dropWell(GS.pointer.x,GS.pointer.y);


### PR DESCRIPTION
## Summary
- Update pointerdown handler to use touch location and drop gravity well at tap position

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a7972afb08331ad1ded4191056dab