### PR TITLE
Scale enemies with screen size and refine shard shape

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,28 +187,38 @@
 
   function spawnShard(minX,minY,maxX,maxY){ return { pos:{x:rand(minX,maxX),y:rand(minY,maxY)}, r:rand(14,22)*GS.dpr, angle:rand(0,Math.PI*2) }; }
   function spawnMines(n){
-    const arr=[]; for(let i=0;i<n;i++) arr.push({ base:{x:rand(GS.w*0.2,GS.w*0.8), y:rand(GS.h*0.2,GS.h*0.8)}, amp:{x:rand(40,140)*(Math.random()<0.5?-1:1)*GS.dpr, y:rand(30,120)*(Math.random()<0.5?-1:1)*GS.dpr}, speed:rand(0.0004,0.001)*(Math.random()<0.5?-1:1), t:Math.random()*Math.PI*2, r:rand(10,16)*GS.dpr, hue:rand(350,20) });
+    const arr=[];
+    const minDim=Math.min(GS.w,GS.h);
+    for(let i=0;i<n;i++) arr.push({
+      base:{x:rand(GS.w*0.2,GS.w*0.8), y:rand(GS.h*0.2,GS.h*0.8)},
+      amp:{x:rand(0.04,0.14)*GS.w*(Math.random()<0.5?-1:1), y:rand(0.03,0.12)*GS.h*(Math.random()<0.5?-1:1)},
+      speed:rand(0.0004,0.001)*(Math.random()<0.5?-1:1),
+      t:Math.random()*Math.PI*2,
+      r:rand(0.03,0.05)*minDim,
+      hue:rand(350,20)
+    });
     return arr;
   }
   const minePos=m=>({x:m.base.x+Math.sin(m.t)*m.amp.x, y:m.base.y+Math.cos(m.t*1.3)*m.amp.y});
 
-  function dropWell(x,y){ if(GS.wells.length>=MAX_WELLS) GS.wells.shift(); GS.wells.push({pos:{x,y},born:GS.time,life:1200}); }
+  function dropWell(x,y){ if(GS.wells.length>=MAX_WELLS) GS.wells.shift(); GS.wells.push({pos:{x,y},born:GS.time,life:2000}); }
   function addPulse(x,y,r0,r1,color){ GS.effects.push({x,y,r0,r1,life:520,born:GS.time,color}); }
 
   // -------- Render primitives --------
   function glowCircle(x,y,r,color,blur=28){ ctx.save(); ctx.shadowBlur=blur; ctx.shadowColor=color; ctx.fillStyle=color; ctx.beginPath(); ctx.arc(x,y,r,0,Math.PI*2); ctx.fill(); ctx.restore(); }
   function ring(x,y,r,color,w=3){ ctx.save(); ctx.strokeStyle=color; ctx.lineWidth=w; ctx.beginPath(); ctx.arc(x,y,r,0,Math.PI*2); ctx.stroke(); ctx.restore(); }
   function drawShard(s){
-    glowCircle(s.pos.x,s.pos.y,s.r*1.4,'#a78bfa');
     ctx.save();
     ctx.translate(s.pos.x,s.pos.y);
     ctx.rotate(s.angle);
     ctx.fillStyle='#a78bfa';
+    ctx.shadowColor='#a78bfa';
+    ctx.shadowBlur=18;
     ctx.beginPath();
     ctx.moveTo(0,-s.r);
-    ctx.lineTo(s.r,0);
-    ctx.lineTo(0,s.r);
-    ctx.lineTo(-s.r,0);
+    ctx.lineTo(s.r*0.6,s.r);
+    ctx.lineTo(0,s.r*0.3);
+    ctx.lineTo(-s.r*0.6,s.r);
     ctx.closePath();
     ctx.fill();
     ctx.restore();


### PR DESCRIPTION
## Summary
- Scale mine size and motion relative to screen dimensions
- Render the collectible shard with a jagged shard-like polygon
- Extend gravity well lifespan so two can coexist

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a7ecc925883318fbb5fb9621147af