### PR TITLE
Use gradient for shard rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,9 +211,13 @@
     ctx.save();
     ctx.translate(s.pos.x,s.pos.y);
     ctx.rotate(s.angle);
-    ctx.fillStyle='#a78bfa';
-    ctx.shadowColor='#a78bfa';
-    ctx.shadowBlur=18;
+    const g=ctx.createLinearGradient(-s.r,-s.r,s.r,s.r);
+    g.addColorStop(0,'#fff');
+    g.addColorStop(0.3,'#e9d5ff');
+    g.addColorStop(1,'#a78bfa');
+    ctx.fillStyle = g;
+    ctx.shadowColor = '#a78bfa';
+    ctx.shadowBlur = 22;
     ctx.beginPath();
     ctx.moveTo(0,-s.r);
     ctx.lineTo(s.r*0.6,s.r);


### PR DESCRIPTION
## Summary
- enhance shard drawing by using a linear gradient and stronger shadow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a860096fc83319442cf70e28bcb6b