### PR TITLE
Add difficulty levels adjusting drag

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,14 @@
       <div class="card">
         <div class="title" id="menuTitle">✨ <span>Slingfield — Neon Gravity</span></div>
         <p style="margin:0 0 12px 0; font-size:14px; color:#cbd5e1">Drop short‑lived gravity wells to bend the comet. Collect shards, avoid mines. Click / tap to place a well. Max two wells, ~1 s cooldown.</p>
+        <label for="difficulty" style="display:block;font-size:14px;color:#cbd5e1;margin:0 0 12px 0">
+          Difficulty
+          <select id="difficulty" style="margin-left:8px;border-radius:8px;padding:6px 10px;background:rgba(255,255,255,.06);color:#e5e7eb;border:1px solid rgba(255,255,255,.1)">
+            <option value="easy">Easy</option>
+            <option value="challenging">Challenging</option>
+            <option value="insane">Insane</option>
+          </select>
+        </label>
         <div class="btns">
           <button class="primary" id="startBtn">New Game</button>
           <button class="ghost" id="howBtn" title="Quick help">How to Play</button>
@@ -97,11 +105,13 @@
   const menuBtn=document.getElementById('menuBtn');
   const finalScore=document.getElementById('finalScore');
   const finalBest=document.getElementById('finalBest');
+  const difficultySelect=document.getElementById('difficulty');
 
   const dpr=Math.max(1,Math.min(2,window.devicePixelRatio||1));
   const MAX_WELLS=2;
+  const DRAG={easy:0.998,challenging:0.999,insane:0.9995};
 
-  const GS={ctx,w:0,h:0,dpr,last:performance.now(),time:0,orb:null,wells:[],shard:null,mines:[],effects:[],cooldownMs:0,level:1,pointer:{x:0,y:0},phase:'menu',best:0,soundOn:true};
+  const GS={ctx,w:0,h:0,dpr,last:performance.now(),time:0,orb:null,wells:[],shard:null,mines:[],effects:[],cooldownMs:0,level:1,pointer:{x:0,y:0},phase:'menu',best:0,soundOn:true,difficulty:'easy'};
 
   const storedBest=Number(localStorage.getItem('slingfield_best'));
   if(!isNaN(storedBest)) GS.best=storedBest;
@@ -293,7 +303,8 @@
     // wells decay + forces
     GS.wells=GS.wells.filter(w=>GS.time-w.born<w.life);
     let ax=0, ay=0; const k=1200*dpr; for(const w of GS.wells){ const dx=w.pos.x-o.pos.x, dy=w.pos.y-o.pos.y; const d2=dx*dx+dy*dy+2000; const f=k/d2; ax+=f*dx; ay+=f*dy; }
-    o.vel.x+=ax*dt/1000; o.vel.y+=ay*dt/1000; o.vel.x*=Math.pow(0.998,dt); o.vel.y*=Math.pow(0.998,dt); o.pos.x+=o.vel.x*dt; o.pos.y+=o.vel.y*dt;
+    const drag=DRAG[GS.difficulty];
+    o.vel.x+=ax*dt/1000; o.vel.y+=ay*dt/1000; o.vel.x*=Math.pow(drag,dt); o.vel.y*=Math.pow(drag,dt); o.pos.x+=o.vel.x*dt; o.pos.y+=o.vel.y*dt;
     // bounds
     const pad=18*dpr; if(o.pos.x<pad){o.pos.x=pad;o.vel.x=Math.abs(o.vel.x)*.92} if(o.pos.x>GS.w-pad){o.pos.x=GS.w-pad;o.vel.x=-Math.abs(o.vel.x)*.92} if(o.pos.y<pad){o.pos.y=pad;o.vel.y=Math.abs(o.vel.y)*.92} if(o.pos.y>GS.h-pad){o.pos.y=GS.h-pad;o.vel.y=-Math.abs(o.vel.y)*.92}
     // mines
@@ -326,7 +337,7 @@
     playSound(110,'sine',0.5,0.25);
     GS.phase='gameover'; cancelAnimationFrame(raf); raf=null; finalScore.textContent=GS.orb.score; GS.best=Math.max(GS.best,GS.orb.score); finalBest.textContent=GS.best; localStorage.setItem('slingfield_best', GS.best); updateHud(); show(menu,false); show(gameover,true);
   }
-  function startGame(){ if(GS.soundOn) initAudio(); GS.phase='playing'; initGame(); show(menu,false); show(gameover,false); canvas.focus(); if(!raf) loop(); }
+  function startGame(){ if(GS.soundOn) initAudio(); GS.difficulty=difficultySelect.value; GS.phase='playing'; initGame(); show(menu,false); show(gameover,false); canvas.focus(); if(!raf) loop(); }
 
   startBtn.onclick=startGame;
   retryBtn.onclick=startGame;


### PR DESCRIPTION
## Summary
- Add difficulty selector (Easy, Challenging, Insane) to game menu
- Apply difficulty-based drag factors with less drag on higher difficulty levels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a988d36e8833197baab23512b214b